### PR TITLE
Backend support for test runs

### DIFF
--- a/alembic/versions/0a1b2c3d4e5f_add_is_test_run_to_survey_participant.py
+++ b/alembic/versions/0a1b2c3d4e5f_add_is_test_run_to_survey_participant.py
@@ -1,0 +1,24 @@
+"""add_is_test_run_to_survey_participant
+
+Revision ID: 0a1b2c3d4e5f
+Revises: fc125248c2cd
+Create Date: 2025-06-30 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '0a1b2c3d4e5f'
+down_revision: Union[str, None] = 'fc125248c2cd'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('survey_participants', sa.Column('is_test_run', sa.Boolean(), nullable=True, server_default=sa.text('false')))
+
+
+def downgrade() -> None:
+    op.drop_column('survey_participants', 'is_test_run')

--- a/app/main.py
+++ b/app/main.py
@@ -336,6 +336,7 @@ async def save_survey_results(
         prolific_pid=result_data.prolific_pid if survey.prolific_enabled else None,
         study_id=result_data.study_id if survey.prolific_enabled else None,
         session_id=result_data.session_id if survey.prolific_enabled else None,
+        is_test_run=result_data.is_test_run if result_data.is_test_run else False,
         consent_given=result_data.consent_given,
         start_time=participant_start_time_to_use,
         end_time=func.now(),  # Aktuelle Zeit als Endzeit
@@ -831,6 +832,7 @@ async def get_survey_results_for_admin(
                 end_time=p.end_time,
                 consent_given=p.consent_given,
                 completed=p.completed,
+                is_test_run=p.is_test_run,
                 responses=answer_details_list,
                 page_durations_log=p.page_durations_log,
             )
@@ -1005,6 +1007,7 @@ async def export_all_data_nested(db: AsyncSession = Depends(get_db_session)):
             end_time=p_obj.end_time,
             consent_given=p_obj.consent_given,
             completed=p_obj.completed,
+            is_test_run=p_obj.is_test_run,
             responses=answer_details_list,
             page_durations_log=p_obj.page_durations_log,
         )
@@ -1127,6 +1130,7 @@ async def export_survey_results_to_csv(
         "end_time",
         "consent_given",
         "completed",
+        "is_test_run",
         "page_durations_log_json",
         "total_paste_count_survey",
         "total_focus_lost_count_survey",
@@ -1179,6 +1183,7 @@ async def export_survey_results_to_csv(
             "end_time": p.end_time.isoformat() if p.end_time else None,
             "consent_given": p.consent_given,
             "completed": p.completed,
+            "is_test_run": p.is_test_run,
             "page_durations_log_json": json.dumps(p.page_durations_log)
             if p.page_durations_log
             else None,

--- a/app/models.py
+++ b/app/models.py
@@ -96,6 +96,7 @@ class SurveyParticipant(Base):
     end_time = Column(DateTime(timezone=True), nullable=True)
     consent_given = Column(Boolean, default=False)
     completed = Column(Boolean, default=False)
+    is_test_run = Column(Boolean, default=False)
 
     page_durations_log = Column(
         JSON, nullable=True

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -34,6 +34,7 @@ class SurveyResultCreate(BaseModel):
     prolific_pid: Optional[str] = None
     study_id: Optional[str] = None
     session_id: Optional[str] = None
+    is_test_run: Optional[bool] = False
     consent_given: bool
     answers: Dict[str, Union[str, List[str], int, float, bool, None]]
     llm_chat_histories: Optional[Dict[str, List[ChatMessage]]] = Field(
@@ -231,6 +232,7 @@ class ParticipantResultDetail(BaseModel):
     end_time: Optional[datetime] = None
     consent_given: bool
     completed: bool
+    is_test_run: Optional[bool] = False
     responses: List[AnswerDetail] = []
 
     page_durations_log: Optional[Dict[str, int]] = None
@@ -280,6 +282,7 @@ class SurveyParticipantExport(BaseModel):
     end_time: Optional[datetime] = None
     consent_given: bool
     completed: bool
+    is_test_run: Optional[bool] = False
     page_durations_log: Optional[Dict[str, int]] = None
     model_config = ConfigDict(from_attributes=True)
 


### PR DESCRIPTION
## Summary
- allow marking test runs via `is_test_run` field on SurveyParticipant
- expose the new flag in API schemas and CSV export
- migration to add `is_test_run` column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c93709d48325bd5074dbc04897d4