### PR TITLE
Implement survey rating stats and default target ratings

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_default_target_ratings_to_surveys.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_default_target_ratings_to_surveys.py
@@ -1,0 +1,28 @@
+"""add_default_target_ratings_to_surveys
+
+Revision ID: a1b2c3d4e5f6
+Revises: 0a1b2c3d4e5f
+Create Date: 2025-07-07 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "0a1b2c3d4e5f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "surveys",
+        sa.Column("default_target_ratings", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("surveys", "default_target_ratings")

--- a/alembic/versions/b7a1e7cb2e3e_add_responses_survey_element_index.py
+++ b/alembic/versions/b7a1e7cb2e3e_add_responses_survey_element_index.py
@@ -1,0 +1,19 @@
+"""add index on responses.survey_element_id"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'b7a1e7cb2e3e'
+down_revision: Union[str, None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index('ix_responses_survey_element_id', 'responses', ['survey_element_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_responses_survey_element_id', table_name='responses')

--- a/app/main.py
+++ b/app/main.py
@@ -432,6 +432,7 @@ async def list_surveys(db: AsyncSession = Depends(get_db_session)):
                 enable_advanced_tracking=getattr(
                     survey, "enable_advanced_tracking", False
                 ),
+                default_target_ratings=survey.default_target_ratings,
             )
         )
     return survey_list_items
@@ -465,6 +466,7 @@ async def create_survey(
         enable_max_duration=survey_in.enable_max_duration,
         max_duration_minutes=survey_in.max_duration_minutes,
         max_duration_warning_minutes=survey_in.max_duration_warning_minutes,
+        default_target_ratings=survey_in.default_target_ratings,
     )
     db.add(new_survey)
     await db.flush()  # Spüle, um die ID der neuen Umfrage zu bekommen
@@ -530,8 +532,103 @@ async def get_survey(survey_id: int, db: AsyncSession = Depends(get_db_session))
         max_duration_warning_minutes=getattr(
             survey, "max_duration_warning_minutes", None
         ),
+        default_target_ratings=getattr(survey, "default_target_ratings", None),
         updated_at=survey.updated_at,
     )
+
+
+# Endpoint to aggregate rating counts per task group
+@app.get(
+    "/api/surveys/{survey_id}/rating-stats",
+    response_model=List[schemas.TaskGroupRatingStat],
+)
+async def get_rating_stats(
+    survey_id: int,
+    randomization_group: Optional[str] = None,
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Return number of ratings per task group for a survey."""
+    survey = await db.execute(
+        select(models.Survey.id).where(models.Survey.id == survey_id)
+    )
+    if survey.scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail="Survey not found")
+
+    stmt = (
+        select(
+            models.SurveyElement.task_identifier,
+            func.count(models.Response.id).label("count"),
+        )
+        .select_from(models.SurveyElement)
+        .outerjoin(
+            models.Response,
+            models.Response.survey_element_id == models.SurveyElement.id,
+        )
+        .where(
+            models.SurveyElement.survey_id == survey_id,
+            models.SurveyElement.task_identifier.isnot(None),
+        )
+    )
+    if randomization_group:
+        stmt = stmt.where(
+            models.SurveyElement.randomization_group == randomization_group
+        )
+    stmt = stmt.group_by(models.SurveyElement.task_identifier)
+    result = await db.execute(stmt)
+    return [
+        {"task_identifier": task_id, "count": count}
+        for task_id, count in result.all()
+    ]
+
+
+# Endpoint to aggregate rating counts per element within task groups
+@app.get(
+    "/api/surveys/{survey_id}/rating-stats/elements",
+    response_model=List[schemas.ElementRatingStat],
+)
+async def get_element_rating_stats(
+    survey_id: int,
+    randomization_group: Optional[str] = None,
+    questions_only: bool = True,
+    distinct_participant: bool = False,
+    db: AsyncSession = Depends(get_db_session),
+):
+    """Return number of ratings per element for a survey."""
+    survey = await db.execute(
+        select(models.Survey.id).where(models.Survey.id == survey_id)
+    )
+    if survey.scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail="Survey not found")
+
+    count_expr = (
+        func.count(func.distinct(models.Response.participant_id))
+        if distinct_participant
+        else func.count(models.Response.id)
+    )
+    stmt = (
+        select(models.SurveyElement.id, count_expr.label("count"))
+        .select_from(models.SurveyElement)
+        .outerjoin(
+            models.Response,
+            models.Response.survey_element_id == models.SurveyElement.id,
+        )
+        .where(
+            models.SurveyElement.survey_id == survey_id,
+            models.SurveyElement.task_identifier.isnot(None),
+        )
+    )
+    if randomization_group:
+        stmt = stmt.where(
+            models.SurveyElement.randomization_group == randomization_group
+        )
+    if questions_only:
+        stmt = stmt.where(models.SurveyElement.element_type == "question")
+    stmt = stmt.group_by(models.SurveyElement.id)
+    result = await db.execute(stmt)
+    return [
+        {"element_id": element_id, "count": count}
+        for element_id, count in result.all()
+    ]
 
 
 # Endpunkt zum Aktualisieren einer bestehenden Umfrage
@@ -592,6 +689,7 @@ async def update_survey(
     db_survey.enable_max_duration = survey_in.enable_max_duration
     db_survey.max_duration_minutes = survey_in.max_duration_minutes
     db_survey.max_duration_warning_minutes = survey_in.max_duration_warning_minutes
+    db_survey.default_target_ratings = survey_in.default_target_ratings
     db_survey.updated_at = func.now()  # Aktualisiere Zeitstempel
 
     # Es ist sicherer, sie explizit zu löschen, um ORM-Überraschungen zu vermeiden.

--- a/app/models.py
+++ b/app/models.py
@@ -40,6 +40,9 @@ class Survey(Base):
     max_duration_warning_minutes = Column(
         Integer, nullable=True
     )  # Vorwarnzeit in Minuten
+    default_target_ratings = Column(
+        Integer, nullable=True
+    )  # Optional global default ratings target per survey
 
     # Beziehung zu SurveyElement (eine Umfrage hat viele Elemente)
     elements = relationship(

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -116,6 +116,7 @@ class SurveyBase(BaseModel):  # Basis für Survey, ohne Validatoren für Create
     enable_max_duration: bool = Field(default=False)
     max_duration_minutes: Optional[int] = Field(default=None, ge=0)
     max_duration_warning_minutes: Optional[int] = Field(default=None, ge=0)
+    default_target_ratings: Optional[int] = Field(default=None, ge=1)
 
 
 class SurveyCreate(SurveyBase):
@@ -163,6 +164,7 @@ class SurveyListItem(BaseModel):
     display_time_spent: bool = Field(default=False)
     enable_max_duration: bool = Field(default=False)
     max_duration_minutes: Optional[int] = None
+    default_target_ratings: Optional[int] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -177,6 +179,17 @@ class SurveyUpdateResponse(BaseModel):
 class SurveyDeleteResponse(BaseModel):
     survey_id: int
     message: str = "Umfrage erfolgreich gelöscht."
+
+
+# Schema for aggregated rating counts per task group
+class TaskGroupRatingStat(BaseModel):
+    task_identifier: str
+    count: int
+
+
+class ElementRatingStat(BaseModel):
+    element_id: int
+    count: int
 
 
 # --- Schemas für Admin Login ---


### PR DESCRIPTION
## Summary
- add `default_target_ratings` field to surveys with migration and schema updates
- implement rating count endpoints for task groups and elements with optional filters
- add index on `responses.survey_element_id` for aggregation queries

## Testing
- `alembic upgrade head`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5d623d4848325b3d5470bf82cddb0